### PR TITLE
add profiles q, theta, u, v, omega, div for ATR

### DIFF
--- a/plots/set_atr_into_context.py
+++ b/plots/set_atr_into_context.py
@@ -25,9 +25,7 @@ atr_circle_segments = [
 l3 = xr.open_dataset(
     f"{settings.root}/products/HALO/dropsondes/Level_3/PERCUSION_Level_3.zarr",
     engine="zarr",
-).assign(
-    wspd_sfc=lambda ds: ds.w_spd.sel(altitude=slice(0, 51)).mean("altitude")
-)
+).assign(wspd_sfc=lambda ds: ds.w_spd.sel(altitude=slice(0, 51)).mean("altitude"))
 l4 = xr.open_dataset(
     f"{settings.root}/products/HALO/dropsondes/Level_4/PERCUSION_Level_4.zarr",
     engine="zarr",
@@ -59,13 +57,25 @@ l4_atr = (
 # %% Level 3
 l3_west = l3.where(l3.aircraft_longitude <= -40, drop=True)
 l3_east = l3.where(l3.aircraft_longitude > -40, drop=True)
-sondes_east_no_atr = [sid for sid in l3_east.sonde_id.values if sid not in l3_atr.sonde_id.values]
-l3_east_no_atr = l3_east.swap_dims({"sonde": "sonde_id"}).sel(sonde_id=sondes_east_no_atr).swap_dims({"sonde_id": "sonde"})
+sondes_east_no_atr = [
+    sid for sid in l3_east.sonde_id.values if sid not in l3_atr.sonde_id.values
+]
+l3_east_no_atr = (
+    l3_east.swap_dims({"sonde": "sonde_id"})
+    .sel(sonde_id=sondes_east_no_atr)
+    .swap_dims({"sonde_id": "sonde"})
+)
 # %% Level 4
 l4_west = l4.where(l4.circle_lon <= -40, drop=True)
 l4_east = l4.where(l4.circle_lon > -40, drop=True)
-circles_east_no_atr = [cid for cid in l4_east.circle_id.values if cid not in l4_atr.circle_id.values]
-l4_east_no_atr = l4_east.swap_dims({"circle": "circle_id"}).sel(circle_id=circles_east_no_atr).swap_dims({"circle_id": "circle"})
+circles_east_no_atr = [
+    cid for cid in l4_east.circle_id.values if cid not in l4_atr.circle_id.values
+]
+l4_east_no_atr = (
+    l4_east.swap_dims({"circle": "circle_id"})
+    .sel(circle_id=circles_east_no_atr)
+    .swap_dims({"circle_id": "circle"})
+)
 
 # %%
 plt.style.use("./beach.mplstyle")
@@ -92,7 +102,9 @@ altmax = 11200
 fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(14, 16), sharey=True)
 print(axes.flatten())
 for ax, var, unit in zip(axes.flatten(), variables, units):
-    for ds, region in zip([l3, l3_west, l3_east_no_atr, l3_atr], ["all", "west", "east", "atr"]):
+    for ds, region in zip(
+        [l3, l3_west, l3_east_no_atr, l3_atr], ["all", "west", "east", "atr"]
+    ):
         ds[var].mean("sonde").sel(altitude=slice(0, altmax)).plot(
             ax=ax, y="altitude", c=colors[region], label=labels[region], zorder=2
         )
@@ -116,10 +128,12 @@ fig.savefig("../images/profiles_east_atr_q_theta_u_v.png", dpi=300, bbox_inches=
 # %% Profiles of divergence and omega
 fig, axes = plt.subplots(ncols=2, figsize=(14, 7), sharey=True)
 for ax, var in zip(axes, ["div", "omega"]):
-    for ds, region in zip([l4, l4_west, l4_east_no_atr, l4_atr], ["all", "west", "east", "atr"]):
+    for ds, region in zip(
+        [l4, l4_west, l4_east_no_atr, l4_atr], ["all", "west", "east", "atr"]
+    ):
         ds[var].mean("circle").sel(altitude=slice(0, altmax)).plot(
             ax=ax, y="altitude", c=colors[region], label=labels[region]
-            )
+        )
     for circle in l4_atr.circle:
         l4_atr.sel(circle=circle)[var].plot(
             ax=ax, y="altitude", c=colors["atr"], alpha=0.1, zorder=1
@@ -137,27 +151,40 @@ fig.savefig("../images/profiles_east_atr_div_omega.png", dpi=300, bbox_inches="t
 # %% Plot the IWV histograms and WS histograms, again for PERCUSION, East, ATR
 fig, axes = plt.subplots(1, 2, figsize=(14, 7))
 for ds, region in zip([l3, l3_east, l3_atr], ["all", "east", "atr"]):
-    for ax, var, bins in zip(axes, ["iwv", "wspd_sfc"], [np.arange(28, 74, 2), np.arange(0, 30, 1)]):
-        ds[var].plot.hist(ax=ax, bins=bins,
-                          density=True, histtype='step', linewidth=3,
-                          color=colors[region], label=labels[region])
+    for ax, var, bins in zip(
+        axes, ["iwv", "wspd_sfc"], [np.arange(28, 74, 2), np.arange(0, 30, 1)]
+    ):
+        ds[var].plot.hist(
+            ax=ax,
+            bins=bins,
+            density=True,
+            histtype="step",
+            linewidth=3,
+            color=colors[region],
+            label=labels[region],
+        )
         ax.axvline(ds[var].median().values, color=colors[region], linewidth=1)
         ax.set_title("")
 
 ax.legend(loc="upper right")
 fig.savefig("../images/hist_east_atr_iwv_ws.png", dpi=300, bbox_inches="tight")
 
+
 # %% Plot PDFs instead of histograms
 def density(x, mu, sigma=0.2):
-    return (1 / (np.sqrt(2 * np.pi * sigma**2)) * np.exp(-0.5 * ((x - mu) / sigma)**2))
+    return 1 / (np.sqrt(2 * np.pi * sigma**2)) * np.exp(-0.5 * ((x - mu) / sigma) ** 2)
+
 
 # %%
 fig, ax = plt.subplots(figsize=(12, 7))
-for ds, region in zip([l3, l3_west, l3_east_no_atr, l3_atr], ["all", "west", "east", "atr"]):
-    density(x=xr.DataArray(data=np.arange(0, 80, 1), dims="nodes"),
-            mu=ds.iwv,
-            sigma=2,
-            ).mean("sonde").plot(x="nodes", color=colors[region], label=labels[region])
+for ds, region in zip(
+    [l3, l3_west, l3_east_no_atr, l3_atr], ["all", "west", "east", "atr"]
+):
+    density(
+        x=xr.DataArray(data=np.arange(0, 80, 1), dims="nodes"),
+        mu=ds.iwv,
+        sigma=2,
+    ).mean("sonde").plot(x="nodes", color=colors[region], label=labels[region])
 ax.set_xlim(25, 75)
 ax.legend(loc="upper left")
 ax.set_ylabel("Probability Density")
@@ -167,11 +194,14 @@ fig.savefig("../images/pdf_east_atr_iwv.png", dpi=300, bbox_inches="tight")
 
 # %%
 fig, ax = plt.subplots(figsize=(12, 7))
-for ds, region in zip([l3, l3_west, l3_east_no_atr, l3_atr], ["all", "west", "east", "atr"]):
-    density(x=xr.DataArray(data=np.arange(0, 40, 1), dims="nodes"),
-            mu=ds.wspd_sfc,
-            sigma=1,
-            ).mean("sonde").plot(x="nodes", color=colors[region], label=labels[region])
+for ds, region in zip(
+    [l3, l3_west, l3_east_no_atr, l3_atr], ["all", "west", "east", "atr"]
+):
+    density(
+        x=xr.DataArray(data=np.arange(0, 40, 1), dims="nodes"),
+        mu=ds.wspd_sfc,
+        sigma=1,
+    ).mean("sonde").plot(x="nodes", color=colors[region], label=labels[region])
 ax.set_xlim(0, 35)
 ax.legend(loc="upper right")
 ax.set_ylabel("Probability Density")


### PR DESCRIPTION
This PR adds two plots that shall set the ATR measurements into the context of the East Atlantic and the full PERCUSION dropsonde measurements. In particular, the theta, RH, u, and v profiles are shown in one plot. And div, omega in a second plot. Profiles in thin yellow lines show the circle (mean) profiles from ATR circles.